### PR TITLE
docs: update README with Playwright installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# playwright-boilerplate
-A simple boilerplate for getting started with Playwright, a powerful browser automation library. This repository provides an initial setup for writing and running end-to-end tests using Playwright, with an example test included to verify that the setup works correctly.
+# Testing Playwright with TypeScript on LambdaTest or Local Machine
+
+## Setup
+* Clone the repository: 
+```bash
+   git clone https://github.com/Gobinath90/playwright-boilerplate.git
+```
+* Navigate to the project directory:
+```bash
+cd playwright-boilerplate
+```
+* Install project dependencies:
+```bash
+npm install
+```
+* Install Playwright browsers: Playwright requires browser binaries to run. You can install them with the following command:
+```bash
+npx playwright install
+```
+If you only want to install Chromium, use:
+
+```bash
+npx playwright install chromium
+```
+
+## Running your tests
+* To run all tests, use, run 
+```bash
+npm run test
+```
+
+## Running Your Allure Report
+
+* Run the tests with the Allure reporter:
+```bash
+playwright test --reporter=allure-playwright
+```
+* Generate the Allure report:
+```bash
+allure generate allure-results --clean -o allure-report
+```
+* Open the Allure report:
+```bash
+allure open allure-report
+```
+


### PR DESCRIPTION
This PR updates the `README.md` file with detailed instructions on how to install Playwright and its required browsers. The updated instructions include:

- Steps for installing Playwright dependencies.
- Instructions to install the Chromium browser using Playwright.
- Enhanced setup guidance to make it easier for new users to get started with Playwright.

The changes aim to provide a clearer and more comprehensive guide for users setting up Playwright for the first time, ensuring they can quickly install the necessary components and begin testing.
